### PR TITLE
Polishing

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -7,7 +7,7 @@
 	<description>Use Nextcloud as an identity provider for external services using the [SCIM](https://scim.cloud/) standard.
 
 Simply add your SCIM servers in the admin settings, and the app will automatically sync all Nextcloud users and groups to your servers.</description>
-	<version>0.1.0</version>
+	<version>0.1.1</version>
 	<licence>agpl</licence>
 	<author mail="contact@edward.ly" homepage="https://edward.ly/">Edward Ly</author>
 	<namespace>ScimClient</namespace>

--- a/lib/Command/Server/Sync.php
+++ b/lib/Command/Server/Sync.php
@@ -42,7 +42,14 @@ class Sync extends Command {
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		try {
 			$name = $input->getArgument('name');
-			$server = $this->scimServerService->getScimServerByName($name)->jsonSerialize();
+			$server = $this->scimServerService->getScimServerByName($name);
+
+			if (!$server) {
+				$output->writeln(sprintf('SCIM server %s not found.', $name));
+				return Command::FAILURE;
+			}
+
+			$server = $server->jsonSerialize();
 			$server['api_key'] = $this->crypto->decrypt($server['api_key']);
 			$this->scimApiService->syncScimServer($server);
 		} catch (\Exception $e) {

--- a/lib/Command/Server/Sync.php
+++ b/lib/Command/Server/Sync.php
@@ -5,7 +5,6 @@ namespace OCA\ScimClient\Command\Server;
 use OCA\ScimClient\AppInfo\Application;
 use OCA\ScimClient\Service\ScimApiService;
 use OCA\ScimClient\Service\ScimServerService;
-use OCP\Security\ICrypto;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -15,7 +14,6 @@ class Sync extends Command {
 	public function __construct(
 		private readonly ScimApiService $scimApiService,
 		private readonly ScimServerService $scimServerService,
-		private readonly ICrypto $crypto,
 	) {
 		parent::__construct();
 	}
@@ -49,9 +47,7 @@ class Sync extends Command {
 				return Command::FAILURE;
 			}
 
-			$server = $server->jsonSerialize();
-			$server['api_key'] = $this->crypto->decrypt($server['api_key']);
-			$this->scimApiService->syncScimServer($server);
+			$this->scimApiService->syncScimServer($server->jsonSerialize());
 		} catch (\Exception $e) {
 			$output->writeln('<error>Failed to sync server</error>');
 			$output->writeln($e->getMessage());

--- a/lib/Command/Server/Update.php
+++ b/lib/Command/Server/Update.php
@@ -4,7 +4,6 @@ namespace OCA\ScimClient\Command\Server;
 
 use OCA\ScimClient\AppInfo\Application;
 use OCA\ScimClient\Service\ScimServerService;
-use OCP\Security\ICrypto;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -14,7 +13,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 class Update extends Command {
 	public function __construct(
 		private readonly ScimServerService $scimServerService,
-		private readonly ICrypto $crypto,
 	) {
 		parent::__construct();
 	}
@@ -66,7 +64,7 @@ class Update extends Command {
 
 		$apiKey = $input->getOption('api-key');
 		if ($apiKey) {
-			$server->setApiKey($this->crypto->encrypt($apiKey));
+			$server->setApiKey($apiKey);
 		}
 
 		$server = $this->scimServerService->updateScimServer($server);

--- a/lib/Controller/ScimServerController.php
+++ b/lib/Controller/ScimServerController.php
@@ -35,7 +35,7 @@ class ScimServerController extends ApiController {
 
 		foreach ($servers as &$server) {
 			// Mask API key with dummy secret if set
-			if (!empty($server['api_key'])) {
+			if ($server['api_key']) {
 				$server['api_key'] = Application::DUMMY_SECRET;
 			}
 		}
@@ -48,7 +48,7 @@ class ScimServerController extends ApiController {
 	public function registerScimServer(array $params): Response {
 		$server = $this->scimServerService->registerScimServer($params);
 
-		if (isset($server)) {
+		if ($server) {
 			$syncParams = ['server_id' => $server->getId()];
 			$this->scimSyncRequestService->addScimSyncRequest($syncParams);
 		}
@@ -63,8 +63,7 @@ class ScimServerController extends ApiController {
 	#[FrontpageRoute(verb: 'PUT', url: '/servers/{id}')]
 	public function updateScimServer(int $id, array $params): Response {
 		// Restore original API key if dummy secret is provided
-		$apiKey = $params['api_key'] ?? null;
-		if ($apiKey === Application::DUMMY_SECRET) {
+		if ($params['api_key'] === Application::DUMMY_SECRET) {
 			$server = $this->scimServerService->getScimServer($id);
 			$params['api_key'] = $server->getApiKey() ?? '';
 		}
@@ -82,7 +81,7 @@ class ScimServerController extends ApiController {
 		}
 
 		// Mask API key with dummy secret if set
-		if (!empty($updatedServer->getApiKey() ?? null)) {
+		if ($updatedServer->getApiKey()) {
 			$updatedServer->setApiKey(Application::DUMMY_SECRET);
 		}
 
@@ -99,7 +98,7 @@ class ScimServerController extends ApiController {
 		$server = $this->scimServerService->unregisterScimServer($server);
 
 		// Do not show API key in response
-		if (isset($server)) {
+		if ($server) {
 			$server = $server->jsonSerialize();
 			unset($server['api_key']);
 		}
@@ -135,7 +134,7 @@ class ScimServerController extends ApiController {
 		$request = $this->scimSyncRequestService->addScimSyncRequest($params);
 
 		return new JSONResponse([
-			'success' => isset($request),
+			'success' => (bool)$request,
 			'request' => $request,
 		]);
 	}

--- a/lib/Cron/Sync.php
+++ b/lib/Cron/Sync.php
@@ -10,7 +10,6 @@ use OCA\ScimClient\Service\ScimServerService;
 use OCA\ScimClient\Service\ScimSyncRequestService;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
-use OCP\Security\ICrypto;
 
 class Sync extends TimedJob {
 
@@ -19,7 +18,6 @@ class Sync extends TimedJob {
 		private readonly ScimApiService $scimApiService,
 		private readonly ScimSyncRequestService $scimSyncRequestService,
 		private readonly ScimServerService $scimServerService,
-		private readonly ICrypto $crypto,
 	) {
 		parent::__construct($time);
 
@@ -33,10 +31,8 @@ class Sync extends TimedJob {
 		foreach ($requests as $request) {
 			$server = $this->scimServerService->getScimServer($request['server_id']);
 
-			if (isset($server)) {
-				$server = $server->jsonSerialize();
-				$server['api_key'] = $this->crypto->decrypt($server['api_key']);
-				$this->scimApiService->syncScimServer($server);
+			if ($server) {
+				$this->scimApiService->syncScimServer($server->jsonSerialize());
 			}
 
 			// TODO: keep the event instead if the sync operation is unsuccessful, write error to server log

--- a/lib/Cron/Update.php
+++ b/lib/Cron/Update.php
@@ -74,25 +74,14 @@ class Update extends TimedJob {
 	private function _generateEventParams(array $event, array $server): array {
 		if ($event['group_id']) {
 			// Get the corresponding group ID on the SCIM server,
-			// or use bulk ID if group hasn't been created yet
-			$groupResults = $this->networkService->request($server, '/Groups', ['filter' => sprintf('externalId eq "%s"', $event['group_id'])], 'GET');
-			if (!isset($groupResults) || isset($groupResults['error'])) {
-				return [];
-			}
-			$group = array_shift($groupResults['Resources']);
-			$groupId = $group ? $group['id'] : ('bulkId:' . $event['group_id']);
+			// or use a bulk ID if group hasn't been created yet
+			$groupId = $this->scimApiService->getScimServerGID($server, $event['group_id']) ?: ('bulkId:' . $event['group_id']);
 		}
 
 		if ($event['user_id']) {
 			// Get the corresponding user ID on the SCIM server,
-			// or use bulk ID if user hasn't been created yet
-			$userResults = $this->networkService->request($server, '/Users', ['filter' => sprintf('externalId eq "%s"', $event['user_id'])], 'GET');
-			if (!isset($userResults) || isset($userResults['error'])) {
-				return [];
-			}
-
-			$user = array_shift($userResults['Resources']);
-			$userId = $user ? $user['id'] : ('bulkId:' . $event['user_id']);
+			// or use a bulk ID if user hasn't been created yet
+			$userId = $this->scimApiService->getScimServerUID($server, $event['user_id']) ?: ('bulkId:' . $event['user_id']);
 		}
 
 		if ($event['event'] === 'UserAddedEvent') {

--- a/lib/Cron/Update.php
+++ b/lib/Cron/Update.php
@@ -80,7 +80,7 @@ class Update extends TimedJob {
 				return [];
 			}
 			$group = array_shift($groupResults['Resources']);
-			$groupId = $group ? $group['id'] : 'bulkId:' . $event['group_id'];
+			$groupId = $group ? $group['id'] : ('bulkId:' . $event['group_id']);
 		}
 
 		if ($event['user_id']) {
@@ -92,7 +92,7 @@ class Update extends TimedJob {
 			}
 
 			$user = array_shift($userResults['Resources']);
-			$userId = $user ? $user['id'] : 'bulkId:' . $event['user_id'];
+			$userId = $user ? $user['id'] : ('bulkId:' . $event['user_id']);
 		}
 
 		if ($event['event'] === 'UserAddedEvent') {

--- a/lib/Cron/Update.php
+++ b/lib/Cron/Update.php
@@ -37,7 +37,7 @@ class Update extends TimedJob {
 	protected function run($argument): void {
 		$events = $this->scimEventService->getScimEvents();
 
-		if (count($events) === 0) {
+		if (!$events) {
 			return;
 		}
 
@@ -47,7 +47,7 @@ class Update extends TimedJob {
 			$config = $this->scimApiService->getScimServerConfig($server);
 
 			$maxBulkOperations = $config['bulk']['maxOperations'];
-			$isBulkOperationsSupported = $config['bulk']['supported'] && $maxBulkOperations > 0;
+			$isBulkOperationsSupported = $config['bulk']['supported'] && $maxBulkOperations;
 
 			if (!$isBulkOperationsSupported) {
 				// TODO: add support for servers without bulk operations

--- a/lib/Db/ScimEvent.php
+++ b/lib/Db/ScimEvent.php
@@ -42,22 +42,22 @@ class ScimEvent extends Entity implements JsonSerializable {
 		$this->addType('feature', Types::STRING);
 		$this->addType('value', Types::STRING);
 
-		if (isset($params['id'])) {
+		if ($params['id']) {
 			$this->setId($params['id']);
 		}
-		if (isset($params['event'])) {
+		if ($params['event']) {
 			$this->setEvent($params['event']);
 		}
-		if (isset($params['group_id'])) {
+		if ($params['group_id']) {
 			$this->setGroupId($params['group_id']);
 		}
-		if (isset($params['user_id'])) {
+		if ($params['user_id']) {
 			$this->setUserId($params['user_id']);
 		}
-		if (isset($params['feature'])) {
+		if ($params['feature']) {
 			$this->setFeature($params['feature']);
 		}
-		if (isset($params['value'])) {
+		if ($params['value']) {
 			$this->setValue($params['value']);
 		}
 	}

--- a/lib/Db/ScimServer.php
+++ b/lib/Db/ScimServer.php
@@ -34,16 +34,16 @@ class ScimServer extends Entity implements JsonSerializable {
 		$this->addType('url', Types::STRING);
 		$this->addType('apiKey', Types::STRING);
 
-		if (isset($params['id'])) {
+		if ($params['id']) {
 			$this->setId($params['id']);
 		}
-		if (isset($params['name'])) {
+		if ($params['name']) {
 			$this->setName($params['name']);
 		}
-		if (isset($params['url'])) {
+		if ($params['url']) {
 			$this->setUrl($params['url']);
 		}
-		if (isset($params['api_key'])) {
+		if ($params['api_key']) {
 			$this->setApiKey($params['api_key']);
 		}
 	}

--- a/lib/Db/ScimSyncRequest.php
+++ b/lib/Db/ScimSyncRequest.php
@@ -26,10 +26,10 @@ class ScimSyncRequest extends Entity implements JsonSerializable {
 	public function __construct(array $params = []) {
 		$this->addType('serverId', Types::BIGINT);
 
-		if (isset($params['id'])) {
+		if ($params['id']) {
 			$this->setId($params['id']);
 		}
-		if (isset($params['server_id'])) {
+		if ($params['server_id']) {
 			$this->setServerId($params['server_id']);
 		}
 	}

--- a/lib/Service/NetworkService.php
+++ b/lib/Service/NetworkService.php
@@ -61,7 +61,7 @@ class NetworkService {
 				],
 			];
 
-			if (count($params) > 0) {
+			if ($params) {
 				if ($method === 'GET') {
 					$url .= '?' . http_build_query($params);
 				} else {

--- a/lib/Service/NetworkService.php
+++ b/lib/Service/NetworkService.php
@@ -78,10 +78,10 @@ class NetworkService {
 			return $jsonResponse ? json_decode($body, true) : $body;
 		} catch (ServerException|ClientException $e) {
 			$body = $e->getResponse()->getBody();
-			$this->logger->warning('SCIM API error : ' . $body, ['app' => Application::APP_ID]);
+			$this->logger->warning('SCIM API error', ['responseBody' => (string)$body, 'exception' => $e]);
 			return ['error' => $e->getMessage()];
 		} catch (Exception|Throwable $e) {
-			$this->logger->warning('SCIM API error', ['exception' => $e, 'app' => Application::APP_ID]);
+			$this->logger->warning('SCIM API error', ['exception' => $e]);
 			return ['error' => $e->getMessage()];
 		}
 	}

--- a/lib/Service/ScimApiService.php
+++ b/lib/Service/ScimApiService.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace OCA\ScimClient\Service;
 
 use OCA\ScimClient\AppInfo\Application;
-use OCP\Http\Client\IClientService;
 use OCP\IGroup;
 use OCP\IGroupManager;
 use OCP\IUser;
@@ -19,13 +18,11 @@ use Psr\Log\LoggerInterface;
 class ScimApiService {
 
 	public function __construct(
-		IClientService $clientService,
 		private readonly IGroupManager $groupManager,
 		private readonly IUserManager $userManager,
 		private readonly NetworkService $networkService,
 		private readonly LoggerInterface $logger,
 	) {
-		$this->client = $clientService->newClient();
 	}
 
 	/**

--- a/lib/Service/ScimApiService.php
+++ b/lib/Service/ScimApiService.php
@@ -104,7 +104,7 @@ class ScimApiService {
 			}
 
 			$userExists = $userResults['totalResults'] > 0;
-			$userPath = $userExists ? '/' . $userResults['Resources'][0]['id'] : '';
+			$userPath = $userExists ? ('/' . $userResults['Resources'][0]['id']) : '';
 
 			return [
 				'method' => $userExists ? 'PUT' : 'POST',
@@ -130,7 +130,6 @@ class ScimApiService {
 		$groupOperations = array_map(function (IGroup $group) use ($serverGroups): array {
 			$operations = [];
 
-			$displayName = $group->getDisplayName();
 			$serverGroupResults = array_filter($serverGroups, fn (array $g): bool => $group->getGID() === $g['externalId']);
 			$serverGroup = array_shift($serverGroupResults);
 
@@ -142,7 +141,7 @@ class ScimApiService {
 					'bulkId' => $group->getGID(),
 					'data' => [
 						'schemas' => [Application::SCIM_CORE_SCHEMA . ':Group'],
-						'displayName' => $displayName,
+						'displayName' => $group->getDisplayName(),
 						'externalId' => $group->getGID(),
 					],
 				];
@@ -158,7 +157,7 @@ class ScimApiService {
 				// Copy group members to server
 				$operations[] = [
 					'method' => 'PATCH',
-					'path' => '/Groups/' . (isset($serverGroup) ? $serverGroup['id'] : 'bulkId:' . $group->getGID()),
+					'path' => '/Groups/' . (isset($serverGroup) ? $serverGroup['id'] : ('bulkId:' . $group->getGID())),
 					'data' => [
 						'schemas' => [Application::SCIM_API_SCHEMA . ':PatchOp'],
 						'Operations' => $addGroupUsers,

--- a/lib/Service/ScimApiService.php
+++ b/lib/Service/ScimApiService.php
@@ -168,13 +168,14 @@ class ScimApiService {
 			return $operations;
 		}, $groups);
 
-		// Try sending the bulk operation regardless of $maxBulkOperations value
-		// All operations should be done in a single bulk request so that the bulkIds are correctly referenced
+		// TODO: split bulk request according to $maxBulkOperations and adjust bulk/server IDs accordingly
 		$params = [
 			'schemas' => [Application::SCIM_API_SCHEMA . ':BulkRequest'],
 			'Operations' => array_values(array_merge($userOperations, ...$groupOperations)),
 		];
 		$response = $this->networkService->request($server, '/Bulk', $params, 'POST');
 		$this->logger->debug('SCIM /Bulk POST', ['responseBody' => $response]);
+
+		// TODO: parse response and handle any errors from each operation
 	}
 }

--- a/lib/Service/ScimApiService.php
+++ b/lib/Service/ScimApiService.php
@@ -66,7 +66,7 @@ class ScimApiService {
 		$results = $this->networkService->request($server, '/Users', $params, 'GET');
 		$this->logger->debug('SCIM /Users GET', ['responseBody' => $results]);
 
-		if (!isset($results) || isset($results['error'])) {
+		if (!$results || $results['error']) {
 			return '';
 		}
 
@@ -87,7 +87,7 @@ class ScimApiService {
 		$results = $this->networkService->request($server, '/Groups', $params, 'GET');
 		$this->logger->debug('SCIM /Groups GET', ['responseBody' => $results]);
 
-		if (!isset($results) || isset($results['error'])) {
+		if (!$results || $results['error']) {
 			return '';
 		}
 
@@ -103,7 +103,7 @@ class ScimApiService {
 	public function verifyScimServer(array $server): array {
 		$config = $this->getScimServerConfig($server);
 
-		if (isset($config['error'])) {
+		if ($config['error']) {
 			return [
 				'error' => 'Unable to fetch SCIM server config',
 				'response' => $config,
@@ -112,7 +112,7 @@ class ScimApiService {
 		}
 
 		$hasScimSchema = $config['schemas'][0] === Application::SCIM_CORE_SCHEMA . ':ServiceProviderConfig';
-		$isBulkOperationsSupported = $config['bulk']['supported'] && $config['bulk']['maxOperations'] > 0;
+		$isBulkOperationsSupported = $config['bulk']['supported'] && $config['bulk']['maxOperations'];
 
 		if (!$hasScimSchema) {
 			return [
@@ -138,12 +138,12 @@ class ScimApiService {
 	public function syncScimServer(array $server): void {
 		$config = $this->getScimServerConfig($server);
 
-		if (isset($config['error'])) {
+		if ($config['error']) {
 			return;
 		}
 
 		$maxBulkOperations = $config['bulk']['maxOperations'];
-		$isBulkOperationsSupported = $config['bulk']['supported'] && $maxBulkOperations > 0;
+		$isBulkOperationsSupported = $config['bulk']['supported'] && $maxBulkOperations;
 
 		if (!$isBulkOperationsSupported) {
 			// TODO: add support for servers without bulk operations
@@ -202,7 +202,7 @@ class ScimApiService {
 				'value' => [['value' => 'bulkId:' . $user->getUID()]],
 			], $group->getUsers());
 
-			if (count($addGroupUsers) > 0) {
+			if ($addGroupUsers) {
 				// Copy group members to server
 				$operations[] = [
 					'method' => 'PATCH',

--- a/lib/Service/ScimServerService.php
+++ b/lib/Service/ScimServerService.php
@@ -22,10 +22,12 @@ class ScimServerService {
 	}
 
 	public function registerScimServer(array $params): ?ScimServer {
-		if (!$params['name']) {
+		$name = trim($params['name']);
+		if (!$name) {
 			$this->logger->error('Failed to register SCIM server. Name cannot be empty.');
 			return null;
 		}
+		$params['name'] = $name;
 
 		if (!str_starts_with($params['url'], 'http://') && !str_starts_with($params['url'], 'https://')) {
 			$this->logger->error('Failed to register SCIM server. URL must start with `http://` or `https://`.');

--- a/lib/Service/ScimServerService.php
+++ b/lib/Service/ScimServerService.php
@@ -22,7 +22,7 @@ class ScimServerService {
 	}
 
 	public function registerScimServer(array $params): ?ScimServer {
-		if (!mb_strlen($params['name'])) {
+		if (!$params['name']) {
 			$this->logger->error('Failed to register SCIM server. Name cannot be empty.');
 			return null;
 		}
@@ -34,7 +34,7 @@ class ScimServerService {
 
 		$params['url'] = rtrim($params['url'], '/');
 
-		if (!empty($params['api_key'])) {
+		if ($params['api_key']) {
 			$params['api_key'] = $this->crypto->encrypt($params['api_key']);
 		}
 
@@ -60,7 +60,7 @@ class ScimServerService {
 			return array_map(function (ScimServer $s): array {
 				$server = $s->jsonSerialize();
 
-				if (!empty($server['api_key'])) {
+				if ($server['api_key']) {
 					$server['api_key'] = $this->crypto->decrypt($server['api_key']);
 				}
 

--- a/lib/Service/ScimSyncRequestService.php
+++ b/lib/Service/ScimSyncRequestService.php
@@ -27,7 +27,7 @@ class ScimSyncRequestService {
 				$this->mapper->delete($duplicateRequest);
 			}
 
-			return isset($request) ? $request : $this->mapper->insert(new ScimSyncRequest($params));
+			return $request ?: $this->mapper->insert(new ScimSyncRequest($params));
 		} catch (Exception $e) {
 			$this->logger->error('Failed to create SCIM sync request. Error: ' . $e->getMessage(), ['exception' => $e]);
 			return null;

--- a/lib/Settings/AdminSettings.php
+++ b/lib/Settings/AdminSettings.php
@@ -26,7 +26,7 @@ class AdminSettings implements ISettings {
 
 		foreach ($servers as &$server) {
 			// Mask API key with dummy secret if set
-			if (!empty($server['api_key'])) {
+			if ($server['api_key']) {
 				$server['api_key'] = Application::DUMMY_SECRET;
 			}
 		}

--- a/src/components/Server/RegisterServerModal.vue
+++ b/src/components/Server/RegisterServerModal.vue
@@ -126,7 +126,7 @@ export default {
 			return this.isEdit ? t('scim_client', 'Edit Server Details') : t('scim_client', 'Register New Server')
 		},
 		isServerNameUnique() {
-			return !this.servers.length || !this.servers.some(server => server.name === this.serverName && server.name !== this.server?.name)
+			return !this.servers.length || !this.servers.some(server => server.name === this.serverName.trim() && server.name !== this.server?.name)
 		},
 		serverNameFieldHelperText() {
 			return this.isServerNameUnique ? '' : t('scim_client', 'A server with this name already exists')
@@ -158,7 +158,7 @@ export default {
 			return this.serverUrl.length && this.isServerUrlValid && this.isServerUrlUnique && this.serverApiKey.length
 		},
 		isFormValidated() {
-			return this.serverName.length && this.isServerNameUnique && this.isServerDetailsValidated
+			return this.serverName.trim().length && this.isServerNameUnique && this.isServerDetailsValidated
 		},
 	},
 	watch: {
@@ -250,7 +250,7 @@ export default {
 		},
 		_buildServerParams() {
 			return {
-				name: this.serverName,
+				name: this.serverName.trim(),
 				url: this.serverUrl,
 				api_key: this.serverApiKey,
 			}


### PR DESCRIPTION
* Use group IDs
* Add debug logs
* Remove unused class attrs
* Adjust verifyScimServer return value

Feedback:

* Make sure to remove the ambiguities when mixing conditional assignment and string concatenation. Use parenthesis for the concatenated string
* Check if you can reproduce the 404 operations when sending valid POST operations for users or groups
```
{"schemas":["urn:ietf:params:scim:api:messages:2.0:BulkResponse"],"Operations":[{"method":"POST","bulkId":"user1","status":404,"response":{"schemas":["urn:ietf:params:scim:api:messages:2.0:Error"],"detail":"Resource not found","status":"404"}},{"method":"POST","bulkId":"user2","status":404,"response":{"schemas":["urn:ietf:params:scim:api:messages:2.0:Error"],"detail":"Resource not found","status":"404"}},{"method":"POST","bulkId":"user3","status":400,"response":{"schemas":["urn:ietf:params:scim:api:messages:2.0:Error"],"detail":"Invalid data!","status":400,"scimType":"invalidSyntax","errors":{"urn:ietf:params:scim:schemas:core:2.0:User:emails":["The urn:ietf:params:scim:schemas:core:2.0: user:emails field is required."]}}},{"method":"POST","bulkId":"user4","status":400,"response":{"schemas":["urn:ietf:params:scim:api:messages:2.0:Error"],"detail":"Invalid data!","status":400,"scimType":"invalidSyntax","errors":{"urn:ietf:params:scim:schemas:core:2.0:User:emails":["The urn:ietf:params:scim:schemas:core:2.0: user:emails field is required."]}}},{"method":"POST","bulkId":"user5","status":400,"response":{"schemas":["urn:ietf:params:scim:api:messages:2.0:Error"],"detail":"Invalid data!","status":400,"scimType":"invalidSyntax","errors":{"urn:ietf:params:scim:schemas:core:2.0:User:emails":["The urn:ietf:params:scim:schemas:core:2.0: user:emails field is required."]}}},{"method":"POST","bulkId":"user6","status":400,"response":{"schemas":["urn:ietf:params:scim:api:messages:2.0:Error"],"detail":"Invalid data!","status":400,"scimType":"invalidSyntax","errors":{"urn:ietf:params:scim:schemas:core:2.0:User:emails":["The urn:ietf:params:scim:schemas:core:2.0: user:emails field is required."]}}},{"location":"http:\/\/localhost\/scim\/v2\/Groups\/9e05d0c8-974e-4103-9520-6b36286fcd46","method":"POST","bulkId":"Wgg1","version":"W\/\"e72847ce7ce2eed7ea7ed99fa1276ecc591cb179\"","status":201}]}
```
* parse the bulk request response and return meaningful info in `ScimApiService::syncScimServer` so the command can output details on what succeeded and what failed