### PR TITLE
fix: add user and group identifiers for bulk IDs

### DIFF
--- a/lib/Cron/Update.php
+++ b/lib/Cron/Update.php
@@ -69,13 +69,13 @@ class Update extends TimedJob {
 		if ($event['group_id']) {
 			// Get the corresponding group ID on the SCIM server,
 			// or use a bulk ID if group hasn't been created yet
-			$groupId = $this->scimApiService->getScimServerGID($server, $event['group_id']) ?: ('bulkId:' . $event['group_id']);
+			$groupId = $this->scimApiService->getScimServerGID($server, $event['group_id']) ?: ('bulkId:Group:' . $event['group_id']);
 		}
 
 		if ($event['user_id']) {
 			// Get the corresponding user ID on the SCIM server,
 			// or use a bulk ID if user hasn't been created yet
-			$userId = $this->scimApiService->getScimServerUID($server, $event['user_id']) ?: ('bulkId:' . $event['user_id']);
+			$userId = $this->scimApiService->getScimServerUID($server, $event['user_id']) ?: ('bulkId:User:' . $event['user_id']);
 		}
 
 		if ($event['event'] === 'UserAddedEvent') {
@@ -120,7 +120,7 @@ class Update extends TimedJob {
 			return [
 				'method' => 'POST',
 				'path' => '/Users',
-				'bulkId' => $event['user_id'],
+				'bulkId' => 'User:' . $event['user_id'],
 				'data' => [
 					'schemas' => [Application::SCIM_CORE_SCHEMA . ':User'],
 					'active' => true,
@@ -183,7 +183,7 @@ class Update extends TimedJob {
 			return [
 				'method' => 'POST',
 				'path' => '/Groups',
-				'bulkId' => $event['group_id'],
+				'bulkId' => 'Group:' . $event['group_id'],
 				'data' => [
 					'schemas' => [Application::SCIM_CORE_SCHEMA . ':Group'],
 					'externalId' => $event['group_id'],

--- a/lib/Service/ScimApiService.php
+++ b/lib/Service/ScimApiService.php
@@ -162,7 +162,7 @@ class ScimApiService {
 			return [
 				'method' => $serverUserId ? 'PUT' : 'POST',
 				'path' => '/Users' . ($serverUserId ? ('/' . $serverUserId) : ''),
-				'bulkId' => $userId,
+				'bulkId' => 'User:' . $userId,
 				'data' => [
 					'schemas' => [Application::SCIM_CORE_SCHEMA . ':User'],
 					'active' => $user->isEnabled(),
@@ -186,7 +186,7 @@ class ScimApiService {
 			$operations[] = [
 				'method' => $serverGroupId ? 'PUT' : 'POST',
 				'path' => '/Groups' . ($serverGroupId ? ('/' . $serverGroupId) : ''),
-				'bulkId' => $groupId,
+				'bulkId' => 'Group:' . $groupId,
 				'data' => [
 					'schemas' => [Application::SCIM_CORE_SCHEMA . ':Group'],
 					'displayName' => $group->getDisplayName(),
@@ -197,14 +197,14 @@ class ScimApiService {
 			$addGroupUsers = array_map(static fn (IUser $user): array => [
 				'op' => 'add',
 				'path' => 'members',
-				'value' => [['value' => 'bulkId:' . $user->getUID()]],
+				'value' => [['value' => 'bulkId:User:' . $user->getUID()]],
 			], $group->getUsers());
 
 			if ($addGroupUsers) {
 				// Copy group members to server
 				$operations[] = [
 					'method' => 'PATCH',
-					'path' => '/Groups/' . ($serverGroupId ?: ('bulkId:' . $groupId)),
+					'path' => '/Groups/' . ($serverGroupId ?: ('bulkId:Group:' . $groupId)),
 					'data' => [
 						'schemas' => [Application::SCIM_API_SCHEMA . ':PatchOp'],
 						'Operations' => $addGroupUsers,


### PR DESCRIPTION
This handles cases where the user and group IDs could be the same (e.g. `admin`).