### PR TITLE
build: add krankerl.toml

### DIFF
--- a/krankerl.toml
+++ b/krankerl.toml
@@ -1,0 +1,5 @@
+[package]
+before_cmds = [
+	"npm ci",
+	"npm run build",
+]


### PR DESCRIPTION
This should trigger the App Store publish workflow to package the app with krankerl rather than make.