### PR TITLE
chore: prepare 1.0.4 hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.4] - 2025-05-21
+
+### Fixed
+
+- Composer scripts for app store publish workflow. #71
+
 ## [1.0.3] - 2025-05-21
 
 ### Added
@@ -46,7 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial app release.
 
-[Unreleased]: https://github.com/nextcloud/scim_client/compare/v1.0.3...HEAD
+[Unreleased]: https://github.com/nextcloud/scim_client/compare/v1.0.4...HEAD
+[1.0.4]: https://github.com/nextcloud/scim_client/compare/v1.0.3...v1.0.4
 [1.0.3]: https://github.com/nextcloud/scim_client/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/nextcloud/scim_client/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/nextcloud/scim_client/compare/v1.0.0...v1.0.1

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -11,7 +11,7 @@
 	<description>Use Nextcloud as an identity provider for external services using the [SCIM](https://scim.cloud/) standard.
 
 Simply add your SCIM servers in the admin settings, and the app will automatically sync all Nextcloud users and groups to your servers.</description>
-	<version>1.0.3</version>
+	<version>1.0.4</version>
 	<licence>agpl</licence>
 	<author mail="contact@edward.ly" homepage="https://edward.ly/">Edward Ly</author>
 	<namespace>ScimClient</namespace>

--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,6 @@
 		}
 	},
 	"scripts": {
-		"post-install-cmd": [
-			"@composer bin all install --ansi"
-		],
-		"post-update-cmd": [
-			"@composer bin all update --ansi"
-		],
 		"lint": "find . -name \\*.php -not -path './vendor/*' -not -path './vendor-bin/*' -not -path './build/*' -print0 | xargs -0 -n1 php -l",
 		"cs:check": "php-cs-fixer fix --dry-run --diff",
 		"cs:fix": "php-cs-fixer fix",
@@ -44,6 +38,13 @@
 		"sort-packages": true,
 		"platform": {
 			"php": "8.1"
+		}
+	},
+	"extra": {
+		"bamarni-bin": {
+			"bin-links": true,
+			"target-directory": "vendor-bin",
+			"forward-command": true
 		}
 	}
 }


### PR DESCRIPTION
This should fix the appstore-build-publish workflow by not installing the dev dependencies.