### PR TITLE
fix(ScimApiService): enable retrieval of user's server ID by username

### DIFF
--- a/lib/Service/ScimApiService.php
+++ b/lib/Service/ScimApiService.php
@@ -80,7 +80,7 @@ class ScimApiService {
 	 */
 	public function getScimServerUID(array $server, string $userId): string {
 		$params = [
-			'filter' => sprintf('externalId eq "%s"', $userId),
+			'filter' => sprintf('externalId eq "%s" or userName eq "%s"', $userId, $userId),
 		];
 		$results = $this->networkService->request($server, '/Users', $params, 'GET');
 		$success = $results && empty($results['error']);


### PR DESCRIPTION
This helps to prevent username conflicts when a user with the same username is already created on the server side.