### PR TITLE
chore: prepare 1.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-07-15
+
+### Changed
+
+- Bump maximum supported Nextcloud version to 35. #181
+- Update npm packages. #158 #159 #160 #162 #165 #168 #169 #171 #172 #176 #178
+- Update GitHub Actions workflows. #161 #170 #180
+- Update composer dependencies. #166
+
 ## [1.3.0] - 2026-04-13
 
 ### Changed
@@ -125,7 +134,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial app release.
 
-[Unreleased]: https://github.com/nextcloud/scim_client/compare/v1.3.0...HEAD
+[Unreleased]: https://github.com/nextcloud/scim_client/compare/v1.4.0...HEAD
+[1.4.0]: https://github.com/nextcloud/scim_client/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/nextcloud/scim_client/compare/v1.2.1...v1.3.0
 [1.2.1]: https://github.com/nextcloud/scim_client/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/nextcloud/scim_client/compare/v1.1.0...v1.2.0

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ Simply add your SCIM servers in the admin settings, and the app will automatical
 	<bugs>https://github.com/nextcloud/scim_client/issues</bugs>
 	<screenshot>https://raw.githubusercontent.com/nextcloud/scim_client/main/img/screenshot-settings-dark.png</screenshot>
 	<dependencies>
-		<nextcloud min-version="30" max-version="34"/>
+		<nextcloud min-version="30" max-version="35"/>
 	</dependencies>
 	<background-jobs>
 		<job>OCA\ScimClient\Cron\Sync</job>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -11,7 +11,7 @@
 	<description>Use Nextcloud as an identity provider for external services using the [SCIM](https://scim.cloud/) standard.
 
 Simply add your SCIM servers in the admin settings, and the app will automatically sync all Nextcloud users and groups to your servers.</description>
-	<version>1.3.0</version>
+	<version>1.4.0</version>
 	<licence>agpl</licence>
 	<author mail="contact@edward.ly" homepage="https://edward.ly/">Edward Ly</author>
 	<namespace>ScimClient</namespace>


### PR DESCRIPTION
### Changed

- Bump maximum supported Nextcloud version to 35. #181
- Update npm packages. #158 #159 #160 #162 #165 #168 #169 #171 #172 #176 #178
- Update GitHub Actions workflows. #161 #170 #180
- Update composer dependencies. #166